### PR TITLE
remove large or negative number vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+npm-debug.log

--- a/src/base58.js
+++ b/src/base58.js
@@ -8,9 +8,9 @@ var alphabetLookup = alphabet.split('').reduce(function (lookup, char, index) {
 	return lookup;
 }, {});
 
-function assertInteger(val) {
-	if (typeof val !== 'number' || isNaN(val) || Math.floor(val) !== val) {
-		throw new Error('Value passed is not an integer.');
+function assertNonNegativeSafeInteger(val) {
+	if (typeof val !== 'number' || isNaN(val) || val < 0 || val > Number.MAX_SAFE_INTEGER || Math.floor(val) !== val) {
+		throw new Error('Value passed is not a non-negative safe integer.');
 	}
 }
 
@@ -33,7 +33,7 @@ exports.encode = function (num) {
 
 	num = Number(num);
 
-	assertInteger(num);
+	assertNonNegativeSafeInteger(num);
 
 	while (num >= base) {
 		modulus = num % base;

--- a/test/base58.test.js
+++ b/test/base58.test.js
@@ -49,7 +49,7 @@ describe('Base58', function () {
 				assert.throws(function () {
 					base58.encode('hi');
 				}, function (err) {
-					return err.message === 'Value passed is not an integer.';
+					return err.message === 'Value passed is not a non-negative safe integer.';
 				});
 			});
 		});
@@ -59,7 +59,7 @@ describe('Base58', function () {
 				assert.throws(function () {
 					base58.encode(3.14);
 				}, function (err) {
-					return err.message === 'Value passed is not an integer.';
+					return err.message === 'Value passed is not a non-negative safe integer.';
 				});
 			});
 		});

--- a/test/base58.test.js
+++ b/test/base58.test.js
@@ -63,6 +63,26 @@ describe('Base58', function () {
 				});
 			});
 		});
+
+		describe('when passed a negative number', function () {
+			it('throws an error', function () {
+				assert.throws(function () {
+					base58.encode(-300);
+				}, function (err) {
+					return err.message === 'Value passed is not a non-negative safe integer.';
+				});
+			});
+		});
+
+		describe('when passed a non-safe integer', function () {
+			it('throws an error', function () {
+				assert.throws(function () {
+					base58.encode(1E100);
+				}, function (err) {
+					return err.message === 'Value passed is not a non-negative safe integer.';
+				});
+			});
+		});
 	});
 
 	describe('.decode', function () {


### PR DESCRIPTION
Using the modulo operator with a very large integer will cause the encoding to crash because eventually we get NaN. Also negative integers should not be allowed as it will screw with the encoding step.