### PR TITLE
Simpler type assertions throwing TypeError

### DIFF
--- a/src/base58.js
+++ b/src/base58.js
@@ -22,10 +22,7 @@ const assertNonNegativeSafeInteger = assertType(
   "Value passed is not a non-negative safe integer."
 );
 
-const assertString = assertType(
-  isString,
-  "Value passed is not a string."
-);
+const assertString = assertType(isString, "Value passed is not a string.");
 
 const assertBase58Character = assertType(
   isBase58Char,

--- a/src/base58.js
+++ b/src/base58.js
@@ -7,29 +7,18 @@ const alphabetLookup = [...alphabet].reduce((lookup, char, index) => {
   return lookup;
 }, {});
 
-function assertNonNegativeSafeInteger(val) {
-  if (
-    typeof val !== "number" ||
-    isNaN(val) ||
-    val < 0 ||
-    val > Number.MAX_SAFE_INTEGER ||
-    Math.floor(val) !== val
-  ) {
-    throw new Error("Value passed is not a non-negative safe integer.");
-  }
+const isSafeNonNegativeInt = (thing) => thing >= 0 && Number.isSafeInteger(thing)
+const isString = (thing) => typeof thing === 'string'
+const isBase58Char = (char) => char in alphabetLookup
+
+const assertType = (checkFn, message) => (value) => {
+  if (!checkFn(value))
+    throw TypeError(message)
 }
 
-function assertString(str) {
-  if (typeof str !== "string") {
-    throw new Error("Value passed is not a string.");
-  }
-}
-
-function assertBase58Character(character) {
-  if (alphabetLookup[character] === undefined) {
-    throw new Error("Value passed is not a valid Base58 string.");
-  }
-}
+const assertNonNegativeSafeInteger = assertType(isSafeNonNegativeInt, "Value passed is not a non-negative safe integer.")
+const assertString = assertType(isString, "Value passed is not a string.")
+const assertBase58Character = assertType(isBase58Char, "Value passed is not a valid Base58 string.")
 
 exports.int_to_base58 = exports.encode = function(num) {
   let str = "";

--- a/src/base58.js
+++ b/src/base58.js
@@ -7,18 +7,18 @@ const alphabetLookup = [...alphabet].reduce((lookup, char, index) => {
   return lookup;
 }, {});
 
-const isSafeNonNegativeInt = (thing) => thing >= 0 && Number.isSafeInteger(thing)
-const isString = (thing) => typeof thing === 'string'
-const isBase58Char = (char) => char in alphabetLookup
+const isSafeNonNegativeInt = thing => thing >= 0 && Number.isSafeInteger(thing);
+const isString = thing => typeof thing === 'string';
+const isBase58Char = char => char in alphabetLookup;
 
-const assertType = (checkFn, message) => (value) => {
+const assertType = (checkFn, message) => value => {
   if (!checkFn(value))
-    throw TypeError(message)
-}
+    throw TypeError(message);
+};
 
-const assertNonNegativeSafeInteger = assertType(isSafeNonNegativeInt, "Value passed is not a non-negative safe integer.")
-const assertString = assertType(isString, "Value passed is not a string.")
-const assertBase58Character = assertType(isBase58Char, "Value passed is not a valid Base58 string.")
+const assertNonNegativeSafeInteger = assertType(isSafeNonNegativeInt, "Value passed is not a non-negative safe integer.");
+const assertString = assertType(isString, "Value passed is not a string.");
+const assertBase58Character = assertType(isBase58Char, "Value passed is not a valid Base58 string.");
 
 exports.int_to_base58 = exports.encode = function(num) {
   let str = "";

--- a/src/base58.js
+++ b/src/base58.js
@@ -8,17 +8,29 @@ const alphabetLookup = [...alphabet].reduce((lookup, char, index) => {
 }, {});
 
 const isSafeNonNegativeInt = thing => thing >= 0 && Number.isSafeInteger(thing);
-const isString = thing => typeof thing === 'string';
+const isString = thing => typeof thing === "string";
 const isBase58Char = char => char in alphabetLookup;
 
 const assertType = (checkFn, message) => value => {
-  if (!checkFn(value))
-    throw TypeError(message);
+  if (!checkFn(value)) {
+    throw new TypeError(message);
+  }
 };
 
-const assertNonNegativeSafeInteger = assertType(isSafeNonNegativeInt, "Value passed is not a non-negative safe integer.");
-const assertString = assertType(isString, "Value passed is not a string.");
-const assertBase58Character = assertType(isBase58Char, "Value passed is not a valid Base58 string.");
+const assertNonNegativeSafeInteger = assertType(
+  isSafeNonNegativeInt,
+  "Value passed is not a non-negative safe integer."
+);
+
+const assertString = assertType(
+  isString,
+  "Value passed is not a string."
+);
+
+const assertBase58Character = assertType(
+  isBase58Char,
+  "Value passed is not a valid Base58 string."
+);
 
 exports.int_to_base58 = exports.encode = function(num) {
   let str = "";


### PR DESCRIPTION
Assertions throw `TypeError`s.

Common function to create checks.

`Number.isSafeInteger(thing)` already checks for type being `number` and value being integer. We just need to make sure it's non-negative at this point.